### PR TITLE
Add workaround for windows for ip fragmentation

### DIFF
--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -10,9 +10,10 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/tsg/gopacket"
 	"net"
 	"strings"
+
+	"github.com/tsg/gopacket"
 )
 
 type IPv4Flag uint8
@@ -141,6 +142,14 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	ip.DstIP = data[16:20]
 	// Set up an initial guess for contents/payload... we'll reset these soon.
 	ip.BaseLayer = BaseLayer{Contents: data}
+
+	// This code is added for the following enviroment:
+	// * Windows 10 with TSO option activated. ( tested on Hyper-V, RealTek ethernet driver )
+	if ip.Length == 0 {
+		// If using TSO(TCP Segmentation Offload), length is zero.
+		// The actual packet length is the length of data.
+		ip.Length = uint16(len(data))
+	}
 
 	if ip.Length < 20 {
 		return fmt.Errorf("Invalid (too small) IP length (%d < 20)", ip.Length)


### PR DESCRIPTION
This PR is meant to solve https://github.com/elastic/beats/issues/2201. The fix is available in the main gopacket repo:https://github.com/google/gopacket/blob/master/layers/ip4.go#L191.
