### PR TITLE
tcp over ipv4 fails to calculate checksum

### DIFF
--- a/layers/tcpip.go
+++ b/layers/tcpip.go
@@ -8,7 +8,9 @@
 package layers
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/tsg/gopacket"
 )
 
@@ -18,27 +20,31 @@ type tcpipchecksum struct {
 }
 
 type tcpipPseudoHeader interface {
-	pseudoheaderChecksum() uint32
+	pseudoheaderChecksum() (uint32, error)
 }
 
-func (ip *IPv4) pseudoheaderChecksum() (csum uint32) {
+func (ip *IPv4) pseudoheaderChecksum() (csum uint32, err error) {
+	if err := ip.AddressTo4(); err != nil {
+		return 0, err
+	}
 	csum += (uint32(ip.SrcIP[0]) + uint32(ip.SrcIP[2])) << 8
 	csum += uint32(ip.SrcIP[1]) + uint32(ip.SrcIP[3])
 	csum += (uint32(ip.DstIP[0]) + uint32(ip.DstIP[2])) << 8
 	csum += uint32(ip.DstIP[1]) + uint32(ip.DstIP[3])
-	csum += uint32(ip.Protocol)
-	return
+	return csum, nil
 }
 
-func (ip *IPv6) pseudoheaderChecksum() (csum uint32) {
+func (ip *IPv6) pseudoheaderChecksum() (csum uint32, err error) {
+	if err := ip.AddressTo16(); err != nil {
+		return 0, err
+	}
 	for i := 0; i < 16; i += 2 {
 		csum += uint32(ip.SrcIP[i]) << 8
 		csum += uint32(ip.SrcIP[i+1])
 		csum += uint32(ip.DstIP[i]) << 8
 		csum += uint32(ip.DstIP[i+1])
 	}
-	csum += uint32(ip.NextHeader)
-	return
+	return csum, nil
 }
 
 // Calculate the TCP/IP checksum defined in rfc1071.  The passed-in csum is any
@@ -60,18 +66,22 @@ func tcpipChecksum(data []byte, csum uint32) uint16 {
 	for csum > 0xffff {
 		csum = (csum >> 16) + (csum & 0xffff)
 	}
-	return ^uint16(csum + (csum >> 16))
+	return ^uint16(csum)
 }
 
 // computeChecksum computes a TCP or UDP checksum.  headerAndPayload is the
 // serialized TCP or UDP header plus its payload, with the checksum zero'd
-// out.
-func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte) (uint16, error) {
+// out. headerProtocol is the IP protocol number of the upper-layer header.
+func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte, headerProtocol IPProtocol) (uint16, error) {
 	if c.pseudoheader == nil {
-		return 0, fmt.Errorf("TCP/IP layer 4 checksum cannot be computed without network layer... call SetNetworkLayerForChecksum to set which layer to use")
+		return 0, errors.New("TCP/IP layer 4 checksum cannot be computed without network layer... call SetNetworkLayerForChecksum to set which layer to use")
 	}
 	length := uint32(len(headerAndPayload))
-	csum := c.pseudoheader.pseudoheaderChecksum()
+	csum, err := c.pseudoheader.pseudoheaderChecksum()
+	if err != nil {
+		return 0, err
+	}
+	csum += uint32(headerProtocol)
 	csum += length & 0xffff
 	csum += length >> 16
 	return tcpipChecksum(headerAndPayload, csum), nil


### PR DESCRIPTION
To fix tcp over ipv4 checksum error, update the tcpip.go file based on official gopacket repo. 