### PR TITLE
pcap: Deal with the first addr being nil

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -544,6 +544,11 @@ func findalladdresses(addresses *_Ctype_struct_pcap_addr) (retval []InterfaceAdd
 	for curaddr := addresses; curaddr != nil; curaddr = (*_Ctype_struct_pcap_addr)(curaddr.next) {
 		var a InterfaceAddress
 		var err error
+		// In case of a tun device on Linux the link layer has no curaddr.addr.
+		// Do not crash trying to check the family type.
+		if curaddr.addr == nil {
+			continue
+		}
 		if a.IP, err = sockaddr_to_IP((*syscall.RawSockaddr)(unsafe.Pointer(curaddr.addr))); err != nil {
 			continue
 		}


### PR DESCRIPTION
In beats issue #4426 packetbeat -devices would crash on a tun device. It
seems that at least with libpcap0.8/Linux 3.13 on Ubuntu 14.04 the first
address of the address list is NULL. Fix the crash by skipping it.

Reproduce using:

ip tuntap add mode tun
ifconfig tun0 172.16.23.1 up
./packetbeat -devices

$12 = {next = 0x23a9e90, name = 0x23aa970 "tun0", description = 0x0, addresses = 0x23aa320, flags = 0}
(gdb) p $12.addresses
$13 = (struct pcap_addr *) 0x23aa320
(gdb) p *$12.addresses
$14 = {next = 0x23aa660, addr = 0x0, netmask = 0x0, broadaddr = 0x0, dstaddr = 0x0}
(gdb) p *$12.addresses.next
$15 = {next = 0x0, addr = 0x23aa690, netmask = 0x23aa6b0, broadaddr = 0x0, dstaddr = 0x23aa6d0}

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12667ae]

goroutine 1 [running]:
github.com/elastic/beats/vendor/github.com/tsg/gopacket/pcap.sockaddr_to_IP(0x0, 0x2, 0x2, 0xe, 0x0, 0x0)
	beats/vendor/github.com/tsg/gopacket/pcap/pcap.go:565 +0x6e
github.com/elastic/beats/vendor/github.com/tsg/gopacket/pcap.findalladdresses(0x40281f0, 0x2, 0x2, 0x6)
	beats/vendor/github.com/tsg/gopacket/pcap/pcap.go:549 +0x178
github.com/elastic/beats/vendor/github.com/tsg/gopacket/pcap.FindAllDevs(0xc420167180, 0xf, 0xf, 0x0, 0x0)
	beats/vendor/github.com/tsg/gopacket/pcap/pcap.go:534 +0x31c
github.com/elastic/beats/packetbeat/sniffer.ListDeviceNames(0x1e50101, 0x0, 0x0, 0x0, 0x0, 0x0)
	beats/packetbeat/sniffer/sniffer.go:81 +0x37
github.com/elastic/beats/packetbeat/beater.init.1.func1(0xc4204e31e0, 0x0, 0xc42024cbc0)
	beats/packetbeat/beater/devices.go:21 +0x49
github.com/elastic/beats/libbeat/beat.FlagsHandlerCallback.HandleFlags(0xc42132f910, 0xc4204e31e0, 0xc42000c1b0, 0x0)
	beats/libbeat/beat/flags.go:35 +0x30
github.com/elastic/beats/libbeat/beat.handleFlags(0xc4204e31e0, 0x0, 0x0)
	beats/libbeat/beat/flags.go:26 +0x60
github.com/elastic/beats/libbeat/beat.(*Beat).handleFlags(0xc4204e31e0, 0x0, 0x0)
	beats/libbeat/beat/beat.go:298 +0x199
github.com/elastic/beats/libbeat/beat.(*Beat).launch(0xc4204e31e0, 0x16823b8, 0x0, 0x0)
	beats/libbeat/beat/beat.go:187 +0x5b
github.com/elastic/beats/libbeat/beat.Run.func1(0x1632855, 0xa, 0x0, 0x0, 0x16823b8, 0x0, 0x0)
	beats/libbeat/beat/beat.go:160 +0x88
github.com/elastic/beats/libbeat/beat.Run(0x1632855, 0xa, 0x0, 0x0, 0x16823b8, 0xc4200001a0, 0xc4200001a0)
	beats/libbeat/beat/beat.go:161 +0x53
main.main()
	beats/packetbeat/main.go:17 +0x57