### PR TITLE
Modify type for the raw link layer

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -88,7 +88,7 @@ const (
 type LinkType uint8
 
 const (
-	// According to pcap-linktype(7).
+	// According to pcap-linktype(7) with fixes from pcap/bpf.h
 	LinkTypeNull           LinkType = 0
 	LinkTypeEthernet       LinkType = 1
 	LinkTypeTokenRing      LinkType = 6
@@ -97,7 +97,7 @@ const (
 	LinkTypePPP            LinkType = 9
 	LinkTypeFDDI           LinkType = 10
 	LinkTypeATM_RFC1483    LinkType = 100
-	LinkTypeRaw            LinkType = 101
+	LinkTypeRaw            LinkType = 12
 	LinkTypePPP_HDLC       LinkType = 50
 	LinkTypePPPEthernet    LinkType = 51
 	LinkTypeC_HDLC         LinkType = 104


### PR DESCRIPTION
According to http://www.tcpdump.org/linktypes.html the value is 101
but in reality it is 12 (and on OpenBSD 14). While browsing through
the list on OpenBSD the DLT_LOOP is 12 (and not 108). In the long it
might make sense to back these values with cgo (and pcap/bpf.h).