### PR TITLE
af_packet: propagate timeout when no packets received

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -16,14 +16,16 @@ package afpacket
 import (
 	"errors"
 	"fmt"
-	"github.com/tsg/gopacket"
-	"github.com/tsg/gopacket/layers"
-	"github.com/tsg/gopacket/pcap"
 	"net"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/tsg/gopacket"
+	"github.com/tsg/gopacket/layers"
+	"github.com/tsg/gopacket/pcap"
 )
 
 /*
@@ -310,7 +312,13 @@ func (h *TPacket) pollForFirstPacket(hdr header) error {
 		h.pollset.events = C.POLLIN
 		h.pollset.revents = 0
 		timeout := C.int(h.opts.timeout / time.Millisecond)
-		_, err := C.poll(&h.pollset, 1, timeout)
+		n, err := C.poll(&h.pollset, 1, timeout)
+		if n == 0 {
+			# propagate timeout when no packets are available
+			# otherwise it will loop forever until a packet
+			# is received.
+			return syscall.EINTR
+		}
 		h.stats.Polls++
 		if err != nil {
 			return err


### PR DESCRIPTION
This patch causes the `syscall.EINTR` error to be produced when the timeout expires and no packets have been received.

Otherwise, the timeout will not be honored until at least one packet arrives.

This is a partial fix for elastic/beats#6535