### PR TITLE
pcap: fix timeout when TPACKET_V3 is used

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -131,6 +131,10 @@ type Handle struct {
 	// huge memory hit, so to handle that we store them here instead.
 	pkthdr  *C.struct_pcap_pkthdr
 	buf_ptr *C.u_char
+	// This is required to poll the pcap handle for incoming packets, due to
+	// newer Linux kernels supporting TPACKET_V3 not starting the timeout until
+	// the first packet is received.
+	packetPoller *packetPoll
 }
 
 // Stats contains statistics on how many packets were handled by a pcap handle,
@@ -206,9 +210,13 @@ func OpenLive(device string, snaplen int32, promisc bool, timeout time.Duration)
 	dev := C.CString(device)
 	defer C.free(unsafe.Pointer(dev))
 
-	p.cptr = C.pcap_open_live(dev, C.int(snaplen), pro, timeoutMillis(timeout), buf)
+	timeoutMs := timeoutMillis(timeout)
+	p.cptr = C.pcap_open_live(dev, C.int(snaplen), pro, timeoutMs, buf)
 	if p.cptr == nil {
 		return nil, errors.New(C.GoString(buf))
+	}
+	if !p.blockForever {
+		p.packetPoller = NewPacketPoll(p.cptr, timeoutMs)
 	}
 	return p, nil
 }
@@ -316,6 +324,9 @@ func (a activateError) Error() string {
 func (p *Handle) getNextBufPtrLocked(ci *gopacket.CaptureInfo) error {
 	var result NextError
 	for {
+		if !p.packetPoller.AwaitForPackets() {
+			return NextErrorTimeoutExpired
+		}
 		result = NextError(C.pcap_next_ex(p.cptr, &p.pkthdr, &p.buf_ptr))
 		if p.blockForever && result == NextErrorTimeoutExpired {
 			continue

--- a/pcap/pcap_poll_common.go
+++ b/pcap/pcap_poll_common.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package pcap
+
+/*
+#include <pcap/pcap.h>
+*/
+import "C"
+
+type packetPoll struct{}
+
+func NewPacketPoll(_ *C.pcap_t, _ C.int) *packetPoll {
+	return nil
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	return true
+}

--- a/pcap/pcap_poll_linux.go
+++ b/pcap/pcap_poll_linux.go
@@ -1,0 +1,52 @@
+// +build linux
+
+package pcap
+
+/*
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <pcap/pcap.h>
+*/
+import "C"
+import "syscall"
+
+// packetPoll holds all the parameters required to use poll(2) on the pcap
+// file descriptor.
+type packetPoll struct {
+	pollfd  C.struct_pollfd
+	timeout C.int
+}
+
+func captureIsTPacketV3(fildes int) bool {
+	version, err := syscall.GetsockoptInt(fildes, syscall.SOL_PACKET, C.PACKET_VERSION)
+	return err == nil && version == C.TPACKET_V3
+}
+
+// NewPacketPoll returns a new packetPoller if the pcap handle requires it
+// in order to timeout effectively when no packets are received. This is only
+// necessary when TPACKET_V3 interface is used to receive packets.
+func NewPacketPoll(ptr *C.pcap_t, timeout C.int) *packetPoll {
+	fildes := C.pcap_fileno(ptr)
+	if !captureIsTPacketV3(int(fildes)) {
+		return nil
+	}
+	return &packetPoll{
+		pollfd: C.struct_pollfd{
+			fd:      fildes,
+			events:  C.POLLIN,
+			revents: 0,
+		},
+		timeout: timeout,
+	}
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	if t != nil {
+		t.pollfd.revents = 0
+		// block until the capture file descriptor is readable or a timeout
+		// happens.
+		n, err := C.poll(&t.pollfd, 1, t.timeout)
+		return err != nil || n != 0
+	}
+	return true
+}


### PR DESCRIPTION
Starting with libpcap 1.8.0, the TPACKET_V3 interface will be used under Linux. This has the side-effect of packet reads not timing out until a packet is received.

This patch detects when TPACKET_V3 is active and uses poll() on the capture file descriptor to ensure packet reads complete within the configured timeout.

Fixes elastic/beats#6535