### PR TITLE
Fix Packetbeat crash when using TPACKET_V3

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -72,6 +72,8 @@ type TPacket struct {
 	pollset C.struct_pollfd
 	// shouldReleasePacket is set to true whenever we return packet data, to make sure we remember to release that data back to the kernel.
 	shouldReleasePacket bool
+	// headerNextNeeded is set to true when header need to move to the next packet. No need to move it case of poll error.
+	headerNextNeeded bool
 	// stats is simple statistics on TPacket's run.
 	stats Stats
 	// tpVersion is the version of TPacket actually in use, set by setRequestedTPacketVersion.
@@ -217,7 +219,7 @@ func (h *TPacket) releaseCurrentPacket() error {
 // TPacket.  Each call to ZeroCopyReadPacketData invalidates any data previously
 // returned by ZeroCopyReadPacketData.  Care must be taken not to keep pointers
 // to old bytes when using ZeroCopyReadPacketData... if you need to keep data past
-// the next time you call ZeroCopyReadPacketData, use ReadPacketDataData, which copies
+// the next time you call ZeroCopyReadPacketData, use ReadPacketData, which copies
 // the bytes into a new buffer for you.
 //  tp, _ := NewTPacket(...)
 //  data1, _, _ := tp.ZeroCopyReadPacketData()
@@ -225,12 +227,13 @@ func (h *TPacket) releaseCurrentPacket() error {
 //  data2, _, _ := tp.ZeroCopyReadPacketData()  // invalidates bytes in data1
 func (h *TPacket) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	h.mu.Lock()
-	if h.current == nil || !h.current.next() {
+	if h.current == nil || !h.headerNextNeeded || !h.current.next() {
 		if h.shouldReleasePacket {
 			h.releaseCurrentPacket()
 		}
 		h.current = h.getTPacketHeader()
 		if err = h.pollForFirstPacket(h.current); err != nil {
+			h.headerNextNeeded = false
 			h.mu.Unlock()
 			return
 		}
@@ -240,6 +243,7 @@ func (h *TPacket) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()
 	h.stats.Packets++
+	h.headerNextNeeded = true
 	h.mu.Unlock()
 	return
 }
@@ -324,6 +328,7 @@ func (h *TPacket) pollForFirstPacket(hdr header) error {
 			return err
 		}
 	}
+
 	h.shouldReleasePacket = true
 	return nil
 }


### PR DESCRIPTION
cherry-pick [b28ce7147a06b23a37cacd4bf2119f9da8dd51c4](https://github.com/google/gopacket/commit/b28ce7147a06b23a37cacd4bf2119f9da8dd51c4) from [google/gopacket](https://github.com/google/gopacket/)

This fixes a Packetbeat crash when TPACKET_V3 is used.

Original message:
```
avoid call to header.next after poll error

In case of a poll error it is a mistake to call
next to the header. This patch introduces a
variable that protect this call.
```