### PR TITLE
Remove unnecessary build directives permanently

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -8,14 +8,6 @@
 package pcap
 
 /*
-#cgo linux LDFLAGS: -lpcap
-#cgo freebsd LDFLAGS: -lpcap
-#cgo openbsd LDFLAGS: -lpcap
-#cgo darwin LDFLAGS: -lpcap
-#cgo solaris LDFLAGS: -lpcap
-#cgo windows CFLAGS: -I C:/WpdPack/Include
-#cgo windows,386 LDFLAGS: -L C:/WpdPack/Lib -lwpcap
-#cgo windows,amd64 LDFLAGS: -L C:/WpdPack/Lib/x64 -lwpcap
 #include <stdlib.h>
 #include <pcap.h>
 


### PR DESCRIPTION
In Packetbeat we constantly patch and unpatch these changes during the build. As we already have a fork it makes no sense. We are also moving away from the folder vendor and we cannot patch the read-only module cache.